### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The following defaults can be overridden in `brunch-config.js`:
       file: '.sass-lint.yml',
       options: {
         ...
-      }
+      },
+      warnOnly: false
     }
   }
   ... 
@@ -38,3 +39,7 @@ The `file` field can be used to specify an alternative YAML configuration for
 `sass-lint`.
 
 The `options` field is passed through unchanged to `sass-lint`.
+
+If the `warnOnly` field is set to `true`, then linting failures will be
+reported as warnings instead of errors, allowing Brunch to continue
+compiling the affected source file(s) even if linting failures occur.

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class SassLint {
         }, this.config.options, this.config.file);
 
         if (result.warningCount === 0 && result.errorCount === 0) {
-            return Promise.resolve(data); 
+            return Promise.resolve();
         }
 
         if (this.config.output) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ class SassLint {
         const cfg = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.sassLint) || {};
         this.linterConfigFile = cfg.file    || '.sass-lint.yml';
         this.linterOptions    = cfg.options || {};
+        this.warnOnly         = (typeof cfg.warnOnly === 'boolean') ? cfg.warnOnly : false;
     }
 
     lint (data, path) {
@@ -21,6 +22,10 @@ class SassLint {
         }
 
         let formattedResults = lint.format([result]);
+
+        if (this.warnOnly) {
+            formattedResults = 'warn: ' + formattedResults;
+        }
 
         return Promise.reject(formattedResults);
     }

--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@
 var lint = require('sass-lint');
 
 class SassLint {
-    constructor (config) {
-        this.config = config && config.plugins && config.plugins.sassLint || {
-            file: '.sass-lint.yml',
-            options: {}
-        };
+    constructor (brunchConfig) {
+        const cfg = (brunchConfig && brunchConfig.plugins && brunchConfig.plugins.sassLint) || {};
+        this.linterConfigFile = cfg.file    || '.sass-lint.yml';
+        this.linterOptions    = cfg.options || {};
     }
 
     lint (data, path) {
@@ -15,7 +14,7 @@ class SassLint {
             text: data,
             format: 'scss',
             filename: path
-        }, this.config.options, this.config.file);
+        }, this.linterOptions, this.linterConfigFile);
 
         if (result.warningCount === 0 && result.errorCount === 0) {
             return Promise.resolve();

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ class SassLint {
     constructor (config) {
         this.config = config && config.plugins && config.plugins.sassLint || {
             file: '.sass-lint.yml',
-            options: {},
-            output: true
+            options: {}
         };
     }
 
@@ -22,11 +21,9 @@ class SassLint {
             return Promise.resolve();
         }
 
-        if (this.config.output) {
-            lint.outputResults([result]);
-        }
-        
-        return Promise.reject(null);
+        let formattedResults = lint.format([result]);
+
+        return Promise.reject(formattedResults);
     }
 }
 

--- a/test.js
+++ b/test.js
@@ -28,11 +28,11 @@ describe('Plugin', () => {
 
     describe('#lint()', () => {
 
-        it('should return the file unchanged', () => {
+        it('should return a resolved Promise on success', () => {
             const data = '.test { display: none; }\n';
 
-            return plugin.lint(data).then(result => {
-                expect(result).to.equal(data);
+            return plugin.lint(data).then(() => {
+                expect(true).to.be.ok;
             }, () => {
                 expect(false).to.be.ok; 
             });

--- a/test.js
+++ b/test.js
@@ -10,7 +10,6 @@ describe('Plugin', () => {
         plugin = new Plugin({
             plugins: {
                 sassLint: {
-                    output: false,
                     file: null,
                     options: {}
                 }
@@ -38,13 +37,13 @@ describe('Plugin', () => {
             });
         });
         
-        it('should fail on errors', () => {
+        it('should return a rejected Promise with error details on failure', () => {
             const data = '.test { display: none; }';
 
             return plugin.lint(data).then(() => {
                 expect(false).to.be.ok; 
-            }, result => {
-                expect(result).to.be.null;
+            }, (errorMessage) => {
+                expect(errorMessage).to.be.string;
             });
         });
 

--- a/test.js
+++ b/test.js
@@ -47,5 +47,37 @@ describe('Plugin', () => {
             });
         });
 
+        it('should report linting failures as errors if warnOnly is false', () => {
+            let plugin = new Plugin({
+                plugins: {
+                    sassLint: { file: null, options: {}, warnOnly: false }
+                }
+            });
+            const data = '.test { display: none; }';
+
+            return plugin.lint(data).then(() => {
+                expect(false).to.be.ok;
+            }, (errorMessage) => {
+                expect(errorMessage).to.be.string;
+                expect(!errorMessage.startsWith('warn: ')).to.be.ok;
+            });
+        });
+
+        it('should report linting failures as warnings if warnOnly is true', () => {
+            let plugin = new Plugin({
+                plugins: {
+                    sassLint: { file: null, options: {}, warnOnly: true }
+                }
+            });
+            const data = '.test { display: none; }';
+
+            return plugin.lint(data).then(() => {
+                expect(false).to.be.ok;
+            }, (errorMessage) => {
+                expect(errorMessage).to.be.string;
+                expect(errorMessage.startsWith('warn: ')).to.be.ok;
+            });
+        });
+
     });
 });


### PR DESCRIPTION
Many thanks @karlspalding for creating this plugin!

I've made a few improvements:
- `4eea3cd` – No parameters should be passed when calling `Promise.resolve()`. See [here](https://github.com/brunch/coffeelint-brunch/blob/2.0.0/index.js#L40), [here](https://github.com/brunch/eslint-brunch/blob/v3.11.1/index.js#L55) and [here](https://github.com/brunch/jshint-brunch/blob/2.0.0/index.js#L55).
- `7f943d9` – Instead of calling [`sassLint.outputResults()`](https://github.com/sasstools/sass-lint/blob/v1.9.1/index.js#L260) to output the error results directly to the console, [`sassLint.format()`](https://github.com/sasstools/sass-lint/blob/v1.9.1/index.js#L242) should be called to generate a string containing the formatted error results which should then be passed to `Promise.reject()` for Brunch to output to the console. See [here](https://github.com/brunch/coffeelint-brunch/blob/2.0.0/index.js#L35), [here](https://github.com/brunch/eslint-brunch/blob/v3.11.1/index.js#L68) and [here](https://github.com/brunch/jshint-brunch/blob/2.0.0/index.js#L87).
- `fa35cac` – Fix bug involving plugin config default values. If `config.plugins.sassLint` is provided, then the default values for both `file` and `options` will be lost. For example, if `config.plugins.sassLint` specifies `options` but doesn't specify `file`, then the plugin won't supply a default value for `file`. An implementation which avoids this problem can be seen [here](https://github.com/brunch/coffeelint-brunch/blob/2.0.0/index.js#L13-L19), [here](https://github.com/brunch/eslint-brunch/blob/v3.11.1/index.js#L43-L46) and [here](https://github.com/brunch/jshint-brunch/blob/2.0.0/index.js#L28-L34).
- `2936f33` – Implement new config option: `warnOnly`. This is a useful feature which has been implemented in other Brunch linting plugins (see [here](https://github.com/brunch/eslint-brunch/blob/v3.11.1/index.js#L65-L67) and [here](https://github.com/brunch/jshint-brunch/blob/2.0.0/index.js#L84-L86)).
